### PR TITLE
Handle error from processCallback (fixes #1).

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -498,7 +498,11 @@ func (c *Conn) RunClientHandshake() error {
 		return err
 	}
 
-	c.processCallback(state.PeerStatic(), payload)
+	err = c.processCallback(state.PeerStatic(), payload)
+	if err != nil {
+		c.in.freeBlock(inBlock)
+		return err
+	}
 	c.in.freeBlock(inBlock)
 
 	if csIn == nil && csOut == nil {


### PR DESCRIPTION
See #1 for details. Checks the return value and if not nil, returns it to the caller.